### PR TITLE
Add: ability to destroy a namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'tty-box', '~> 0.7.0'
 gem 'tty-prompt', git: 'https://github.com/seawolf/tty-prompt.git', branch: 'auto-select-only-option'
 gem 'zeitwerk', '~> 2.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,15 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
+    strings (0.2.1)
+      strings-ansi (~> 0.2)
+      unicode-display_width (>= 1.5, < 3.0)
+      unicode_utils (~> 1.4)
+    strings-ansi (0.2.0)
+    tty-box (0.7.0)
+      pastel (~> 0.8)
+      strings (~> 0.2.0)
+      tty-cursor (~> 0.7)
     tty-color (0.6.0)
     tty-cursor (0.7.1)
     tty-reader (0.9.0)
@@ -63,6 +72,7 @@ GEM
       wisper (~> 2.0)
     tty-screen (0.8.1)
     unicode-display_width (2.0.0)
+    unicode_utils (1.4.0)
     wisper (2.0.1)
     zeitwerk (2.4.2)
 
@@ -74,6 +84,7 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
   simplecov
+  tty-box (~> 0.7.0)
   tty-prompt!
   zeitwerk (~> 2.4)
 

--- a/app/turbulence/gcloud/actions.rb
+++ b/app/turbulence/gcloud/actions.rb
@@ -7,7 +7,8 @@ module Turbulence
         ConnectToContainer,
         TailLogsSingleContainer,
         TailLogsAllContainers,
-        RestartDeployment
+        RestartDeployment,
+        DestroyNamespace
       ].freeze
     end
   end

--- a/app/turbulence/gcloud/actions/destroy_namespace.rb
+++ b/app/turbulence/gcloud/actions/destroy_namespace.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Turbulence
+  module GCloud
+    module Actions
+      # Destroy all resources in a namespace
+      class DestroyNamespace
+        ID = :destroy_namespace
+        NAME = 'Destroy all resources in a namespace'
+
+        include ActionResources
+
+        def run
+          project
+          cluster
+          namespace
+
+          confirmation = confirm
+          confirmation && destroy || bail_out
+
+          confirmation
+        end
+
+        private
+
+        def connection
+          "kubectl delete namespace #{namespace.name}"
+        end
+
+        def connect
+          system(connection)
+        end
+
+        def confirm
+          Turbulence::MessageBox.warning([
+            'This action is IRREVERSIBLE !',
+            'All of the pods, containers, ingresses, etc. within the namespace will be permenantly destroyed.',
+            'It may take some minutes, through which there is no opportunity to pause or abort.'
+          ].join("\n\n"))
+
+          PROMPT.select("Destroy the \"#{namespace.name}\" namespace?", {
+                          No: false,
+                          Yes: true
+                        })
+        end
+
+        def destroy
+          PROMPT.ok("\nDestroying...\n")
+          connect
+          PROMPT.ok("\nDestroyed.\n")
+        end
+
+        def bail_out
+          PROMPT.ok("\nNamespace preserved.\n")
+        end
+      end
+    end
+  end
+end

--- a/app/turbulence/message_box.rb
+++ b/app/turbulence/message_box.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'tty-box'
+
+module Turbulence
+  # Interface to and tweaks on top of TTY:Box
+  module MessageBox
+    module_function
+
+    def warning(message)
+      colour_scheme = { fg: :white, bg: :red }
+      style = colour_scheme.merge({ border: colour_scheme })
+
+      print "\n", TTY::Box.warn(message, style: style)
+    end
+  end
+end

--- a/spec/unit/turbulence/gcloud/actions/destroy_namespace_spec.rb
+++ b/spec/unit/turbulence/gcloud/actions/destroy_namespace_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe Turbulence::GCloud::Actions::DestroyNamespace do
+  let(:instance) { described_class.new }
+
+  let(:project) { instance_double(Turbulence::GCloud::Resources::Project::Project, id: 'my-project') }
+  let(:cluster) { instance_double(Turbulence::GCloud::Resources::Cluster::Cluster, name: 'my-cluster') }
+  let(:namespace) { instance_double(Turbulence::GCloud::Resources::Namespace::Namespace, name: 'my-namespace') }
+  let(:connection) { 'kubectl delete namespace my-namespace' }
+  let(:confirmed) { true }
+
+  before do
+    allow(Turbulence::Menu::PROMPT).to receive(:ok)
+
+    allow(instance).to receive_messages(
+      project: project,
+      cluster: cluster,
+      namespace: namespace,
+      confirm: confirmed,
+      system: true
+    )
+  end
+
+  describe '#run' do
+    subject do
+      instance.run
+    end
+
+    after do
+      subject
+    end
+
+    context 'having confirmed' do
+      it 'runs the command wrapped in whatever `kubectl` needs to get there' do
+        expect(instance).to receive(:system).once.with(connection)
+      end
+    end
+
+    context 'having aborted' do
+      let(:confirmed) { false }
+
+      it 'does not run any command' do
+        expect(instance).not_to receive(:system).with(connection)
+      end
+    end
+  end
+end

--- a/spec/unit/turbulence/message_box_spec.rb
+++ b/spec/unit/turbulence/message_box_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Turbulence::MessageBox do
+  describe '.warning' do
+    subject { described_class.warning(message) }
+
+    let(:message) { 'Hello World!' }
+
+    it 'prints an appropriately-styled warning message', silent_output: true do
+      expect(::TTY::Box).to receive(:warn).with('Hello World!', style: {
+                                                  fg: :white,
+                                                  bg: :red,
+                                                  border: {
+                                                    fg: :white,
+                                                    bg: :red
+                                                  }
+                                                })
+
+      subject
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to destroy a namespace, after confirming the action.

It may take some time, due to Google Cloud deleting the various components.