### PR TITLE
Add: attach to a running container; fallback to non-foreground pods

### DIFF
--- a/app/turbulence/gcloud/actions.rb
+++ b/app/turbulence/gcloud/actions.rb
@@ -5,6 +5,7 @@ module Turbulence
     module Actions
       LIST = [
         ConnectToContainer,
+        AttachToContainer,
         TailLogsSingleContainer,
         TailLogsAllContainers,
         RestartDeployment,

--- a/app/turbulence/gcloud/actions/attach_to_container.rb
+++ b/app/turbulence/gcloud/actions/attach_to_container.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Turbulence
+  module GCloud
+    module Actions
+      # Attach to a running container in a pod
+      class AttachToContainer
+        ID = :attach
+        NAME = 'Attach to a running container in a pod'
+
+        include ActionResources
+
+        def run
+          project
+          cluster
+          namespace
+          pod
+          container
+
+          PROMPT.ok("\nConnecting...\n")
+          connect
+        end
+
+        private
+
+        def connection
+          "kubectl attach -it #{pod.id} -n #{namespace.name} -c #{container.name}"
+        end
+
+        def connect
+          system(connection)
+        end
+      end
+    end
+  end
+end

--- a/app/turbulence/gcloud/resources/pod.rb
+++ b/app/turbulence/gcloud/resources/pod.rb
@@ -47,18 +47,26 @@ module Turbulence
             '{.metadata.name}'\
             '{"\n"}'\
             '{end}'\
-            "' | grep foreground"
+            "'"
+        end
+
+        def all_pods_list
+          `#{pods_list_command}`
+        end
+
+        def foreground_pods_list
+          `#{pods_list_command} | grep foreground`
         end
 
         def pods_list
-          `#{pods_list_command}`.tap do |result|
-            result || exit(1)
-          end
+          foreground_pods_list.split("\n").presence ||
+            all_pods_list.split("\n").presence ||
+            exit(1)
         end
         # :nocov:
 
         def pods
-          pods_list.split("\n").map do |line|
+          pods_list.map do |line|
             Pod.new(line)
           end
         end

--- a/lib/core_ext/array.rb
+++ b/lib/core_ext/array.rb
@@ -4,4 +4,8 @@ class Array
   def present?
     length.positive?
   end
+
+  def presence
+    present? ? self : nil
+  end
 end

--- a/spec/unit/turbulence/gcloud/actions/attach_to_container_spec.rb
+++ b/spec/unit/turbulence/gcloud/actions/attach_to_container_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe Turbulence::GCloud::Actions::AttachToContainer do
+  let(:instance) { described_class.new }
+
+  let(:project) { instance_double(Turbulence::GCloud::Resources::Project::Project, id: 'my-project') }
+  let(:cluster) { instance_double(Turbulence::GCloud::Resources::Cluster::Cluster, name: 'my-cluster') }
+  let(:namespace) { instance_double(Turbulence::GCloud::Resources::Namespace::Namespace, name: 'my-namespace') }
+  let(:pod) { instance_double(Turbulence::GCloud::Resources::Pod::Pod, id: 'my-pod') }
+  let(:container) { instance_double(Turbulence::GCloud::Resources::Container::Container, name: 'my-container') }
+  let(:connection) { 'kubectl attach -it my-pod -n my-namespace -c my-container' }
+
+  before do
+    allow(Turbulence::Menu::PROMPT).to receive_messages(
+      select: project
+    )
+    allow(instance).to receive_messages(
+      project: project,
+      cluster: cluster,
+      namespace: namespace,
+      pod: pod,
+      container: container,
+      system: true
+    )
+  end
+
+  describe '#run' do
+    subject do
+      instance.run
+    end
+
+    after do
+      subject
+    end
+
+    it 'runs the command wrapped in whatever `kubectl` needs to get there' do
+      expect(instance).to receive(:system).once.with(connection)
+    end
+  end
+end

--- a/spec/unit/turbulence/gcloud/resources/pod_spec.rb
+++ b/spec/unit/turbulence/gcloud/resources/pod_spec.rb
@@ -39,12 +39,13 @@ describe Turbulence::GCloud::Resources::Pod do
 
     shared_examples :fetching_and_selecting_a_pod do
       before do
-        allow(instance).to receive(:pods_list).and_return(pods_list.join("\n"))
+        allow(instance).to receive(:foreground_pods_list).and_return('')
+        allow(instance).to receive(:all_pods_list).and_return(pods_list.join("\n"))
         allow(Turbulence::Menu).to receive(:auto_select).and_return(pod)
       end
 
       it 'fetches a new Pod' do
-        expect(instance).to receive(:pods_list).and_return(pods_list.join("\n"))
+        expect(instance).to receive(:all_pods_list).and_return(pods_list.join("\n"))
 
         subject
       end


### PR DESCRIPTION
This PR adds;
1. the action to attach to a running container via `kubectl attach` alongside an option to connect via `kubectl exec`.
2. a fallback to the Pod look-up process, in case none are named `foreground` in the selected project/namespace/etc.
