### PR TITLE
Add: forward one of a pod's ports to the local machine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # match the Ruby version with GitHub Actions workflow:
 FROM ruby:3.0.0-slim
 
+EXPOSE 25863
+
 WORKDIR /usr/src
 
 #####

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,22 @@
 .DEFAULT_GOAL := run
-.PHONY: all build run shell clean vacuum
+.PHONY: all build build_fresh run shell clean vacuum
 
 all: clean run
 
-build:
+build: config.yml
 	@ docker-compose build
+
+build_fresh: config.yml
+	@ docker-compose build --no-cache
 
 config.yml:
 	@ [ -f config.yml ] || touch config.yml
 
 run: config.yml
-	@ docker-compose run --rm app
+	@ docker-compose run --rm --service-ports app
 
 shell: config.yml
-	@ docker-compose run --rm --entrypoint=/bin/bash app
+	@ docker-compose run --rm --service-ports --entrypoint=/bin/bash app
 
 clean:
 	@ docker-compose down

--- a/app/turbulence/gcloud/actions.rb
+++ b/app/turbulence/gcloud/actions.rb
@@ -8,6 +8,7 @@ module Turbulence
         AttachToContainer,
         TailLogsSingleContainer,
         TailLogsAllContainers,
+        ForwardPort,
         RestartDeployment,
         DestroyNamespace
       ].freeze

--- a/app/turbulence/gcloud/actions/forward_port.rb
+++ b/app/turbulence/gcloud/actions/forward_port.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Turbulence
+  module GCloud
+    module Actions
+      # Allows access to a pod's TCP port by forawrding onto Turbulence and Docker-Compose
+      class ForwardPort
+        ID = :forward_port
+        NAME = 'Set-up Port Forwarding from a pod to the host'
+        TURBULENCE_PORT = 25_683
+
+        include ActionResources
+
+        def run
+          project
+          cluster
+          namespace
+          pod
+          pod_port
+
+          PROMPT.ok("\nConnecting...\n")
+          connect
+        end
+
+        private
+
+        def connection
+          "kubectl port-forward -n #{namespace.name} #{pod.id} --address 0.0.0.0 #{TURBULENCE_PORT}:#{pod_port}"
+        end
+
+        def connect
+          system(connection)
+        end
+
+        def pod_port
+          raise "No ports exposed by the #{pod.id} pod!" if pod_ports.list.empty?
+
+          Menu.auto_select("Ports exposed by the the \"#{pod.id}\" pod:", pod_ports.choices,
+                           per_page: pod_ports.list.length)
+        end
+
+        def pod_ports
+          @pod_ports ||= PodPorts.new(namespace, pod)
+        end
+      end
+    end
+  end
+end

--- a/app/turbulence/gcloud/actions/forward_port.rb
+++ b/app/turbulence/gcloud/actions/forward_port.rb
@@ -35,7 +35,7 @@ module Turbulence
         def pod_port
           raise "No ports exposed by the #{pod.id} pod!" if pod_ports.list.empty?
 
-          Menu.auto_select("Ports exposed by the the \"#{pod.id}\" pod:", pod_ports.choices,
+          Menu.auto_select("Ports exposed by the \"#{pod.id}\" pod:", pod_ports.choices,
                            per_page: pod_ports.list.length)
         end
 

--- a/app/turbulence/gcloud/actions/forward_port/pod_ports.rb
+++ b/app/turbulence/gcloud/actions/forward_port/pod_ports.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Turbulence
+  module GCloud
+    module Actions
+      class ForwardPort
+        # List of ports exposed by a Pod
+        class PodPorts
+          def initialize(namespace, pod)
+            @namespace = namespace
+            @pod = pod
+          end
+
+          def choices
+            list.map do |choice|
+              {
+                name: choice,
+                value: choice
+              }
+            end
+          end
+
+          def list
+            ports.split("\n").compact
+          end
+
+          private
+
+          attr_reader :namespace, :pod
+
+          def ports
+            return @ports if defined?(@ports)
+
+            @ports = connect
+          end
+
+          # :nocov:
+          def connect
+            `#{connection}`
+          end
+          # :nocov:
+
+          def connection
+            "kubectl get pod -n #{namespace.name} #{pod.id} "\
+                "--template='"\
+                  '{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'\
+                  "'"
+          end
+        end
+      end
+    end
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - .:/usr/src
       - gcloud_auth:/root/.config
       - kube_config:/root/.kube
+    ports:
+    - '25683:25683' # phoneword for CLOUD
 
 volumes:
   gcloud_auth: {}

--- a/spec/unit/turbulence/gcloud/actions/forward_port/pod_ports_spec.rb
+++ b/spec/unit/turbulence/gcloud/actions/forward_port/pod_ports_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+describe Turbulence::GCloud::Actions::ForwardPort::PodPorts do
+  let(:instance) { described_class.new(namespace, pod) }
+
+  let(:namespace) { instance_double(Turbulence::GCloud::Resources::Namespace::Namespace, name: 'my-namespace') }
+  let(:pod) { instance_double(Turbulence::GCloud::Resources::Pod::Pod, id: 'my-pod') }
+  let(:connection) { 'kubectl get pod -n my-namespace my-pod --template' }
+
+  before do
+    allow(instance).to receive_messages(
+      namespace: namespace,
+      pod: pod,
+      connect: "80\n8080\n"
+    )
+  end
+
+  describe '#list' do
+    subject do
+      instance.list
+    end
+
+    after do
+      subject
+    end
+
+    it 'runs the command wrapped in whatever `kubectl` needs to get there' do
+      expect(instance).to receive(:connect).once
+    end
+
+    it 'connects with the expected command' do
+      expect(instance.send(:connection)).to start_with(connection)
+    end
+
+    it('lists the exposed ports') { is_expected.to eq(%w[80 8080]) }
+  end
+
+  describe '#choices' do
+    subject { instance.choices }
+
+    it 'lists the exposed ports as menu items' do
+      is_expected.to eq([
+                          {
+                            name: '80',
+                            value: '80'
+                          },
+                          {
+                            name: '8080',
+                            value: '8080'
+                          }
+                        ])
+    end
+  end
+end

--- a/spec/unit/turbulence/gcloud/actions/forward_port_spec.rb
+++ b/spec/unit/turbulence/gcloud/actions/forward_port_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe Turbulence::GCloud::Actions::ForwardPort do
+  let(:instance) { described_class.new }
+
+  let(:project) { instance_double(Turbulence::GCloud::Resources::Project::Project, id: 'my-project') }
+  let(:cluster) { instance_double(Turbulence::GCloud::Resources::Cluster::Cluster, name: 'my-cluster') }
+  let(:namespace) { instance_double(Turbulence::GCloud::Resources::Namespace::Namespace, name: 'my-namespace') }
+  let(:pod) { instance_double(Turbulence::GCloud::Resources::Pod::Pod, id: 'my-pod') }
+  let(:connection) { 'kubectl port-forward -n my-namespace my-pod --address 0.0.0.0 25683:8080' }
+
+  before do
+    allow(Turbulence::Menu::PROMPT).to receive_messages(
+      select: project,
+      ok: true
+    )
+    allow(instance).to receive_messages(
+      project: project,
+      cluster: cluster,
+      namespace: namespace,
+      pod: pod,
+      pod_port: '8080',
+      system: true
+    )
+  end
+
+  describe '#run' do
+    subject do
+      instance.run
+    end
+
+    after do
+      subject
+    end
+
+    it 'runs the command wrapped in whatever `kubectl` needs to get there' do
+      expect(instance).to receive(:system).once.with(connection)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the ability to forward local traffic from a port to one of a pod's ports.

Traffic from the local port 25683 is routed to Turbulence by Docker Compose, then the app does the same from Turbulence to the selected port by `kubectl port-forward`.
    ![i-heart-graphviz](https://user-images.githubusercontent.com/193455/161724685-14150004-8f78-42d2-a2a2-e652d8a24a42.png)

This addition could make it possible for a pod to directly handle traffic without public ingress being created.

At present, only one port can be forwarded at a time, consequently one copy of Turbulence can be run. To address the latter, remove the `ports` section of `docker-compose.yml`.

The actions menu has a new item:
    ![menu item](https://user-images.githubusercontent.com/193455/161580969-6703c6bf-c7ec-4247-ad7b-f192516db15a.png)

Traffic is handled directly:
    ![sending traffic to the pod](https://user-images.githubusercontent.com/193455/161580985-fc6d2b24-3a2e-4774-9611-618f54a7730d.png)