### PR TITLE
Del: filtering the Pod list based on title

### DIFF
--- a/app/turbulence/gcloud/resources/pod.rb
+++ b/app/turbulence/gcloud/resources/pod.rb
@@ -54,14 +54,8 @@ module Turbulence
           `#{pods_list_command}`
         end
 
-        def foreground_pods_list
-          `#{pods_list_command} | grep foreground`
-        end
-
         def pods_list
-          foreground_pods_list.split("\n").presence ||
-            all_pods_list.split("\n").presence ||
-            exit(1)
+          all_pods_list.split("\n").presence || exit(1)
         end
         # :nocov:
 

--- a/spec/unit/turbulence/gcloud/resources/pod_spec.rb
+++ b/spec/unit/turbulence/gcloud/resources/pod_spec.rb
@@ -39,7 +39,6 @@ describe Turbulence::GCloud::Resources::Pod do
 
     shared_examples :fetching_and_selecting_a_pod do
       before do
-        allow(instance).to receive(:foreground_pods_list).and_return('')
         allow(instance).to receive(:all_pods_list).and_return(pods_list.join("\n"))
         allow(Turbulence::Menu).to receive(:auto_select).and_return(pod)
       end


### PR DESCRIPTION
Once upon a time, all the projects to which I was connecting using Turbulence were named in such a way that I only cared about pods named "foreground" - this is no longer the case, so I'm removing the filter that prevents me from accessing pods that I need to access.

You may get a big list but there's the as-you-type filtering to help, and everything is visible now.