### PR TITLE
Add: installation of gke-gcloud-auth-plugin, ready for K8s 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN curl https://sdk.cloud.google.com > /tmp/install-gcloud &&\
 
 RUN echo "source /root/google-cloud-sdk/completion.bash.inc" >> /root/.bashrc
 RUN echo "source /root/google-cloud-sdk/path.bash.inc" >> /root/.bashrc
-RUN bash -lc "gcloud components install kubectl"
+RUN echo "export USE_GKE_GCLOUD_AUTH_PLUGIN=True" >> /root/.bashrc
+RUN bash -lc "gcloud components install kubectl gke-gcloud-auth-plugin"
 
 #####
 # Configure Ruby and co.


### PR DESCRIPTION
Fixes #11 for upcoming changes to Kubernetes that will require some changes in the way Turbulence authenticates with GCP.

This follows the guidance to install the tooling, and enable it earlier than required.

The message continues to display, but including the `gke-gcloud-auth-plugin --version` verification step shows it is installed.