### PR TITLE
Up: update the Docker image to use Python v3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /usr/src
 RUN apt-get update && apt-get install -y \
     curl \
     git \
-    python
+    python3
 
 RUN curl https://sdk.cloud.google.com > /tmp/install-gcloud &&\
     chmod +x /tmp/install-gcloud &&\


### PR DESCRIPTION
When running a sufficiently fresh build of Turbulence, the Google Cloud SDK informs/advises:

```
WARNING:  Python 2 will soon be deprecated by the Google Cloud SDK                                                                                                                                                        
and may not function correctly. Please use Python version 3.5 and up.                                                                                                                                                     
                                                                                                                                                                                                                          
If you have a compatible Python interpreter installed, you can use it by setting                                                                                                                                          
the CLOUDSDK_PYTHON environment variable to point to it.  
```

This PR updates the application environment for Google Cloud SDK to use Python 3.

The application continues to connect successfully:

<img height="250" alt="image" src="https://user-images.githubusercontent.com/193455/189097947-fb9cc9e2-16f2-4f9c-8a34-d4d265cacbbd.png">