### PR TITLE
chore(Docker): upgrade to Ruby 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0'] # match with Dockerfile
+        ruby-version: ['3.2'] # match with Dockerfile
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN curl https://sdk.cloud.google.com > /tmp/install-gcloud &&\
 RUN echo "source /root/google-cloud-sdk/completion.bash.inc" >> /root/.bashrc
 RUN echo "source /root/google-cloud-sdk/path.bash.inc" >> /root/.bashrc
 RUN echo "export USE_GKE_GCLOUD_AUTH_PLUGIN=True" >> /root/.bashrc
+RUN bash -lc "gcloud components update"
 RUN bash -lc "gcloud components install kubectl gke-gcloud-auth-plugin"
 
 #####

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # match the Ruby version with GitHub Actions workflow:
-FROM ruby:3.0.0-slim
+FROM ruby:3.2.0-slim
 
 EXPOSE 25863
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)


### PR DESCRIPTION
Upgrades the base image from Ruby 3.0 to Ruby 3.2, including the GitHub workflow system.

Additionally, the GGLoud SDK has been seen to state that some components need updating, so this is included in the build/installation process.