### PR TITLE
Add: action to download a remote file to the local computer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 config.yml
 
-.devcontainer/
+Downloads/*
 
+.devcontainer/
 spec/coverage
+
+!*/.gitkeep

--- a/app/turbulence/gcloud/actions.rb
+++ b/app/turbulence/gcloud/actions.rb
@@ -9,6 +9,7 @@ module Turbulence
         TailLogsSingleContainer,
         TailLogsAllContainers,
         ForwardPort,
+        DownloadFile,
         RestartDeployment,
         DestroyNamespace
       ].freeze

--- a/app/turbulence/gcloud/actions/download_file.rb
+++ b/app/turbulence/gcloud/actions/download_file.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Turbulence
+  module GCloud
+    module Actions
+      # Downlaods a file from a pod
+      class DownloadFile
+        ID = :download_file
+        NAME = 'Download a file from a Pod to your computer'
+
+        include ActionResources
+
+        def run
+          project
+          cluster
+          namespace
+          pod
+          container
+          remote_file
+          download_destination
+
+          PROMPT.ok("\nConnecting...\n")
+          download &&
+            PROMPT.ok("\nThe file is now in the Downloads folder of your Turbulence installation.")
+        end
+
+        private
+
+        attr_reader :remote_file_path, :remote_file_name
+
+        def remote_file
+          return @remote_file if defined?(@remote_file)
+
+          @remote_file = PROMPT.ask('Full path and filename of remote file: (e.g. /tmp/my-file)', required: true)
+          @remote_file_path = File.dirname(remote_file)
+          @remote_file_name = File.basename(remote_file)
+
+          @remote_file
+        end
+
+        def download_destination
+          system('[ -d ./Downloads ] || mkdir Downloads')
+        end
+
+        def command
+          "kubectl cp -n #{namespace.name} -c #{container.name} " \
+            "#{pod.id}:#{remote_file} ./Downloads/#{remote_file_name}"
+        end
+
+        def download
+          system(command)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/turbulence/gcloud/actions/download_file_spec.rb
+++ b/spec/unit/turbulence/gcloud/actions/download_file_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+describe Turbulence::GCloud::Actions::DownloadFile do
+  let(:instance) { described_class.new }
+
+  let(:project) { instance_double(Turbulence::GCloud::Resources::Project::Project, id: 'my-project') }
+  let(:cluster) { instance_double(Turbulence::GCloud::Resources::Cluster::Cluster, name: 'my-cluster') }
+  let(:namespace) { instance_double(Turbulence::GCloud::Resources::Namespace::Namespace, name: 'my-namespace') }
+  let(:pod) { instance_double(Turbulence::GCloud::Resources::Pod::Pod, id: 'my-pod') }
+  let(:container) { instance_double(Turbulence::GCloud::Resources::Container::Container, name: 'my-container') }
+  let(:command) { 'kubectl cp -n my-namespace -c my-container my-pod:/usr/src/some-file.ext ./Downloads/some-file.ext' }
+
+  before do
+    allow(Turbulence::Menu::PROMPT).to receive_messages(
+      ask: '/usr/src/some-file.ext',
+      ok: true
+    )
+    allow(instance).to receive_messages(
+      project: project,
+      cluster: cluster,
+      namespace: namespace,
+      pod: pod,
+      container: container,
+      system: true
+    )
+  end
+
+  describe '#run' do
+    subject do
+      instance.run
+    end
+
+    after do
+      subject
+    end
+
+    it 'prepares the local download location' do
+      expect(instance).to receive(:system)
+        .with(a_string_matching(' -d ./Downloads ')).once
+    end
+
+    it 'runs the command wrapped in whatever `kubectl` needs to get there' do
+      expect(instance).to receive(:system)
+        .with(command).once
+    end
+
+    it 'asks what file should be downloaded' do
+      expect(Turbulence::Menu::PROMPT).to receive(:ask).once.with(
+        'Full path and filename of remote file: (e.g. /tmp/my-file)',
+        required: true
+      ).and_return('/usr/src/some-file.ext')
+    end
+
+    context 'when the download fails' do
+      before do
+        allow(instance).to receive(:system).with(command).and_return(false)
+      end
+
+      it 'does not confirm the download (leaving the output)' do
+        expect(Turbulence::Menu::PROMPT).not_to receive(:ok)
+          .with(a_string_matching('The file is now in the Downloads folder'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows the download of a file from a Pod filesystem into the local machine.

Due to Turbulence being run in Docker, the local filesystem access is restricted to the Turbulence source code directory. A folder for the downloads is made within it, and the files are downloaded there. The "real" local machine then has access via the Docker mounts.